### PR TITLE
Fix achievements dashboard invocation

### DIFF
--- a/src/achievements_dashboard.py
+++ b/src/achievements_dashboard.py
@@ -512,4 +512,3 @@ def render_achievements_dashboard():
 
 if __name__ == "__main__":
     render_achievements_dashboard()
-    render_achievements_dashboard()


### PR DESCRIPTION
## Summary
- remove duplicate call to render_achievements_dashboard

## Testing
- `python -m py_compile src/main.py src/achievements_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_684f170aef9c8325b1085adb24fed4d3